### PR TITLE
Attach the sources during packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,20 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>


### PR DESCRIPTION
Since this project is Open Source, it is very handy to have Maven
download the sources for the jars found in central.

Some projects also attach javadoc, but the sources provide javadoc
(at least with IJ) so I find that they just take up space.
