### PR TITLE
Use less threads to keep the number of open files smaller

### DIFF
--- a/src/test/java/com/maxmind/db/MultiThreadedTest.java
+++ b/src/test/java/com/maxmind/db/MultiThreadedTest.java
@@ -70,7 +70,7 @@ public class MultiThreadedTest {
 
     private static void runThreads(Callable<JsonNode> task)
             throws InterruptedException, ExecutionException {
-        int threadCount = 1024;
+        int threadCount = 256;
         List<Callable<JsonNode>> tasks = Collections.nCopies(threadCount, task);
         ExecutorService executorService = Executors
                 .newFixedThreadPool(threadCount);


### PR DESCRIPTION
This patch fix the OS X build in general and makes travis happy again.
