### PR TITLE
Optimizations for String decoding

### DIFF
--- a/src/main/java/com/maxmind/db/Decoder.java
+++ b/src/main/java/com/maxmind/db/Decoder.java
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.databind.node.*;
  * This class CANNOT be shared between threads
  */
 final class Decoder {
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
     // XXX - This is only for unit testings. We should possibly make a
     // constructor to set this
     boolean POINTER_TEST_HACK = false;
@@ -183,9 +185,11 @@ final class Decoder {
     }
 
     private String decodeString(int size) {
-        ByteBuffer buffer = this.buffer.slice();
-        buffer.limit(size);
-        return Charset.forName("UTF-8").decode(buffer).toString();
+        int oldLimit = buffer.limit();
+        buffer.limit(buffer.position() + size);
+        String s = UTF_8.decode(buffer).toString();
+        buffer.limit(oldLimit);
+        return s;
     }
 
     private IntNode decodeUint16(int size) {

--- a/src/main/java/com/maxmind/db/Decoder.java
+++ b/src/main/java/com/maxmind/db/Decoder.java
@@ -3,7 +3,9 @@ package com.maxmind.db;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,6 +25,8 @@ final class Decoder {
     private final long pointerBase;
 
     private final ObjectMapper objectMapper;
+
+    private final CharsetDecoder utfDecoder = UTF_8.newDecoder();
 
     private final ByteBuffer buffer;
 
@@ -184,10 +188,10 @@ final class Decoder {
         return new Result(new LongNode(pointer), offset + pointerSize);
     }
 
-    private String decodeString(int size) {
+    private String decodeString(int size) throws CharacterCodingException {
         int oldLimit = buffer.limit();
         buffer.limit(buffer.position() + size);
-        String s = UTF_8.decode(buffer).toString();
+        String s = utfDecoder.decode(buffer).toString();
         buffer.limit(oldLimit);
         return s;
     }


### PR DESCRIPTION

The library creates an excessive amount of garbage. To address this, a thorough redesign would be needed (see issue #13). In the meantime, here's a small patch that reduces allocations around Decoder#decodeString, incidentally also improving performance by 10-20%.