### PR TITLE
Improve benchmark

### DIFF
--- a/sample/Benchmark.java
+++ b/sample/Benchmark.java
@@ -11,25 +11,43 @@ import com.maxmind.db.Reader.FileMode;
 
 public class Benchmark {
 
-    public static void main(String[] args) throws IOException,
-            InvalidDatabaseException {
-        File file = new File("GeoLite2-City.mmdb");
+    private final static int COUNT = 1000000;
+    private final static int WARMUPS = 3;
+    private final static int BENCHMARKS = 5;
+    private final static boolean TRACE = false;
 
-        Reader r = new Reader(file, FileMode.MEMORY_MAPPED);
-        Random random = new Random();
-        int count = 1000000;
+    public static void main(String[] args) throws IOException, InvalidDatabaseException {
+        File file = new File(args.length > 0 ? args[0] : "GeoLite2-City.mmdb");
+        loop("Warming up", file, WARMUPS);
+        loop("Benchmarking", file, BENCHMARKS);
+    }
+
+    private static void loop(String msg, File file, int loops) throws IOException {
+        System.out.println(msg);
+        for (int i = 0; i < loops; i++) {
+            Reader r = new Reader(file, FileMode.MEMORY_MAPPED);
+            bench(r, COUNT, i);
+        }
+        System.out.println();
+    }
+
+    private static void bench(Reader r, int count, int seed) throws IOException {
+        Random random = new Random(seed);
         long startTime = System.nanoTime();
         for (int i = 0; i < count; i++) {
             InetAddress ip = InetAddresses.fromInteger(random.nextInt());
-            if (i % 50000 == 0) {
-                System.out.println(i + " " + ip);
-            }
             JsonNode t = r.get(ip);
+            if (TRACE) {
+                if (i % 50000 == 0) {
+                    System.out.println(i + " " + ip);
+                    System.out.println(t);
+                }
+            }
         }
         long endTime = System.nanoTime();
 
         long duration = endTime - startTime;
-        System.out.println("Requests per second: " + count * 1000000000.0
-                / (duration));
+        long qps = count * 1000000000L / duration;
+        System.out.println("Requests per second: " + qps);
     }
 }

--- a/sample/Benchmark.java
+++ b/sample/Benchmark.java
@@ -4,7 +4,6 @@ import java.net.InetAddress;
 import java.util.Random;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.net.InetAddresses;
 import com.maxmind.db.InvalidDatabaseException;
 import com.maxmind.db.Reader;
 import com.maxmind.db.Reader.FileMode;
@@ -34,8 +33,10 @@ public class Benchmark {
     private static void bench(Reader r, int count, int seed) throws IOException {
         Random random = new Random(seed);
         long startTime = System.nanoTime();
+        byte[] address = new byte[4];
         for (int i = 0; i < count; i++) {
-            InetAddress ip = InetAddresses.fromInteger(random.nextInt());
+            random.nextBytes(address);
+            InetAddress ip = InetAddress.getByAddress(address);
             JsonNode t = r.get(ip);
             if (TRACE) {
                 if (i % 50000 == 0) {


### PR DESCRIPTION
Benchmark results might vary based on a number of factors. I tend to select a fixed random seed so the test run is repeatable. Also, I disable Intel's Turbo Boost feature, so it doesn't vary the CPU frequency with overclocking. I run the benchmark loop multiple times, so the JIT is warmed up. With these tweaks, you get more consistent and meaningful results.
