### PR TITLE
Optional caching of JSON nodes

### DIFF
--- a/sample/Benchmark.java
+++ b/sample/Benchmark.java
@@ -4,7 +4,10 @@ import java.net.InetAddress;
 import java.util.Random;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.maxmind.db.CHMCache;
 import com.maxmind.db.InvalidDatabaseException;
+import com.maxmind.db.NoCache;
+import com.maxmind.db.NodeCache;
 import com.maxmind.db.Reader;
 import com.maxmind.db.Reader.FileMode;
 
@@ -17,14 +20,19 @@ public class Benchmark {
 
     public static void main(String[] args) throws IOException, InvalidDatabaseException {
         File file = new File(args.length > 0 ? args[0] : "GeoLite2-City.mmdb");
-        loop("Warming up", file, WARMUPS);
-        loop("Benchmarking", file, BENCHMARKS);
+        System.out.println("No caching");
+        loop("Warming up", file, WARMUPS, new NoCache());
+        loop("Benchmarking", file, BENCHMARKS, new NoCache());
+
+        System.out.println("With caching");
+        loop("Warming up", file, WARMUPS, new CHMCache());
+        loop("Benchmarking", file, BENCHMARKS, new CHMCache());
     }
 
-    private static void loop(String msg, File file, int loops) throws IOException {
+    private static void loop(String msg, File file, int loops, NodeCache cache) throws IOException {
         System.out.println(msg);
         for (int i = 0; i < loops; i++) {
-            Reader r = new Reader(file, FileMode.MEMORY_MAPPED);
+            Reader r = new Reader(file, FileMode.MEMORY_MAPPED, cache);
             bench(r, COUNT, i);
         }
         System.out.println();

--- a/src/main/java/com/maxmind/db/CHMCache.java
+++ b/src/main/java/com/maxmind/db/CHMCache.java
@@ -1,0 +1,51 @@
+package com.maxmind.db;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ContainerNode;
+
+/**
+ * A simplistic cache using a {@link ConcurrentHashMap}. There's no eviction
+ * policy, it just fills up until reaching the specified capacity <small>(or
+ * close enough at least, bounds check is not atomic :)</small>
+ */
+public class CHMCache implements NodeCache {
+
+    private static final int DEFAULT_CAPACITY = 4096;
+
+    private final int capacity;
+    private final ConcurrentHashMap<Integer, JsonNode> cache;
+    private boolean cacheFull = false;
+
+    public CHMCache() {
+        this(DEFAULT_CAPACITY);
+    }
+
+    public CHMCache(int capacity) {
+        this.capacity = capacity;
+        this.cache = new ConcurrentHashMap<Integer, JsonNode>(capacity);
+    }
+
+    @Override
+    public JsonNode get(int key, Loader loader) throws IOException {
+        Integer k = key;
+        JsonNode value = cache.get(k);
+        if (value == null) {
+            value = loader.load(key);
+            if (!cacheFull) {
+                if (cache.size() < capacity) {
+                    cache.put(k, value);
+                } else {
+                    cacheFull = true;
+                }
+            }
+        }
+        if (value instanceof ContainerNode) {
+            value = value.deepCopy();
+        }
+        return value;
+    }
+
+}

--- a/src/main/java/com/maxmind/db/NoCache.java
+++ b/src/main/java/com/maxmind/db/NoCache.java
@@ -1,0 +1,17 @@
+package com.maxmind.db;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * A no-op cache.
+ */
+public class NoCache implements NodeCache {
+
+    @Override
+    public JsonNode get(int key, Loader loader) throws IOException {
+        return loader.load(key);
+    }
+
+}

--- a/src/main/java/com/maxmind/db/NodeCache.java
+++ b/src/main/java/com/maxmind/db/NodeCache.java
@@ -1,0 +1,15 @@
+package com.maxmind.db;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface NodeCache {
+
+    public interface Loader {
+        JsonNode load(int key) throws IOException;
+    }
+
+    public JsonNode get(int key, Loader loader) throws IOException;
+
+}

--- a/src/test/java/com/maxmind/db/DecoderTest.java
+++ b/src/test/java/com/maxmind/db/DecoderTest.java
@@ -414,6 +414,8 @@ public class DecoderTest {
     private static <T> void testTypeDecoding(Decoder.Type type, Map<T, byte[]> tests)
             throws IOException {
 
+        NodeCache cache = new CHMCache();
+
         for (Map.Entry<T, byte[]> entry : tests.entrySet()) {
             T expect = entry.getKey();
             byte[] input = entry.getValue();
@@ -423,7 +425,7 @@ public class DecoderTest {
             MappedByteBuffer mmap = fc.map(MapMode.READ_ONLY, 0, fc.size());
             try {
 
-                Decoder decoder = new Decoder(mmap, 0);
+                Decoder decoder = new Decoder(cache, mmap, 0);
                 decoder.POINTER_TEST_HACK = true;
 
                 // XXX - this could be streamlined

--- a/src/test/java/com/maxmind/db/PointerTest.java
+++ b/src/test/java/com/maxmind/db/PointerTest.java
@@ -20,7 +20,7 @@ public class PointerTest {
         File file = new File(PointerTest.class.getResource(
                 "/maxmind-db/test-data/maps-with-pointers.raw").toURI());
         BufferHolder ptf = new BufferHolder(file, FileMode.MEMORY);
-        Decoder decoder = new Decoder(ptf.get(), 0);
+        Decoder decoder = new Decoder(new NoCache(), ptf.get(), 0);
 
         ObjectMapper om = new ObjectMapper();
 


### PR DESCRIPTION
Defaults to no caching. A simple bounded cache implementation using ConcurrentHashMap is provided (CHMCache). When caching is applied, ContainerNodes are always deep-copied. This way the cached instances remain immutable.

Even with a very modest cache size, this yields a good hit-rate and a major speedup (~3x on the low-level benchmark, ~2x on the high-level API) along with a significant reduction in object churn (refs #13).
