### PR TITLE
eliminate Decoder.Result objects

### DIFF
--- a/src/main/java/com/maxmind/db/Reader.java
+++ b/src/main/java/com/maxmind/db/Reader.java
@@ -131,7 +131,7 @@ public final class Reader implements Closeable {
         int start = this.findMetadataStart(buffer, name);
 
         Decoder metadataDecoder = new Decoder(this.cache, buffer, start);
-        this.metadata = new Metadata(metadataDecoder.decode(start).getNode());
+        this.metadata = new Metadata(metadataDecoder.decode(start));
 
         this.ipV4Start = this.findIpV4StartNode(buffer);
     }
@@ -251,7 +251,7 @@ public final class Reader implements Closeable {
         // found.
         Decoder decoder = new Decoder(this.cache, buffer,
                 this.metadata.getSearchTreeSize() + DATA_SECTION_SEPARATOR_SIZE);
-        return decoder.decode(resolved).getNode();
+        return decoder.decode(resolved);
     }
 
     /*

--- a/src/test/java/com/maxmind/db/DecoderTest.java
+++ b/src/test/java/com/maxmind/db/DecoderTest.java
@@ -430,36 +430,28 @@ public class DecoderTest {
 
                 // XXX - this could be streamlined
                 if (type.equals(Decoder.Type.BYTES)) {
-                    assertArrayEquals(desc, (byte[]) expect, decoder.decode(0)
-                            .getNode().binaryValue());
+                    assertArrayEquals(desc, (byte[]) expect, decoder.decode(0).binaryValue());
                 } else if (type.equals(Decoder.Type.ARRAY)) {
-                    assertEquals(desc, expect, decoder.decode(0).getNode());
+                    assertEquals(desc, expect, decoder.decode(0));
                 } else if (type.equals(Decoder.Type.UINT16)
                         || type.equals(Decoder.Type.INT32)) {
-                    assertEquals(desc, expect, decoder.decode(0).getNode()
-                            .asInt());
+                    assertEquals(desc, expect, decoder.decode(0).asInt());
                 } else if (type.equals(Decoder.Type.UINT32)
                         || type.equals(Decoder.Type.POINTER)) {
-                    assertEquals(desc, expect, decoder.decode(0).getNode()
-                            .asLong());
+                    assertEquals(desc, expect, decoder.decode(0).asLong());
                 } else if (type.equals(Decoder.Type.UINT64)
                         || type.equals(Decoder.Type.UINT128)) {
-                    assertEquals(desc, expect, decoder.decode(0).getNode()
-                            .bigIntegerValue());
+                    assertEquals(desc, expect, decoder.decode(0).bigIntegerValue());
                 } else if (type.equals(Decoder.Type.DOUBLE)) {
-                    assertEquals(desc, expect, decoder.decode(0).getNode()
-                            .asDouble());
+                    assertEquals(desc, expect, decoder.decode(0).asDouble());
                 } else if (type.equals(Decoder.Type.FLOAT)) {
-                    assertEquals(desc, new FloatNode((Float) expect), decoder
-                            .decode(0).getNode());
+                    assertEquals(desc, new FloatNode((Float) expect), decoder.decode(0));
                 } else if (type.equals(Decoder.Type.UTF8_STRING)) {
-                    assertEquals(desc, expect, decoder.decode(0).getNode()
-                            .asText());
+                    assertEquals(desc, expect, decoder.decode(0).asText());
                 } else if (type.equals(Decoder.Type.BOOLEAN)) {
-                    assertEquals(desc, expect, decoder.decode(0).getNode()
-                            .asBoolean());
+                    assertEquals(desc, expect, decoder.decode(0).asBoolean());
                 } else {
-                    assertEquals(desc, expect, decoder.decode(0).getNode());
+                    assertEquals(desc, expect, decoder.decode(0));
                 }
             } finally {
                 fc.close();

--- a/src/test/java/com/maxmind/db/PointerTest.java
+++ b/src/test/java/com/maxmind/db/PointerTest.java
@@ -23,26 +23,26 @@ public class PointerTest {
 
         ObjectNode map = om.createObjectNode();
         map.put("long_key", "long_value1");
-        assertEquals(map, decoder.decode(0).getNode());
+        assertEquals(map, decoder.decode(0));
 
         map = om.createObjectNode();
         map.put("long_key", "long_value2");
-        assertEquals(map, decoder.decode(22).getNode());
+        assertEquals(map, decoder.decode(22));
 
         map = om.createObjectNode();
         map.put("long_key2", "long_value1");
-        assertEquals(map, decoder.decode(37).getNode());
+        assertEquals(map, decoder.decode(37));
 
         map = om.createObjectNode();
         map.put("long_key2", "long_value2");
-        assertEquals(map, decoder.decode(50).getNode());
+        assertEquals(map, decoder.decode(50));
 
         map = om.createObjectNode();
         map.put("long_key", "long_value1");
-        assertEquals(map, decoder.decode(55).getNode());
+        assertEquals(map, decoder.decode(55));
 
         map = om.createObjectNode();
         map.put("long_key2", "long_value2");
-        assertEquals(map, decoder.decode(57).getNode());
+        assertEquals(map, decoder.decode(57));
     }
 }


### PR DESCRIPTION
The ByteBuffer itself keeps track of the read position. Reduces object churn (#13), also simplifies the code. 