### PR TITLE
immutable ContainerNodes to avoid deep copies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.4</version>
+            <version>2.7.0</version>
         </dependency>
     </dependencies>
     <properties>

--- a/src/main/java/com/maxmind/db/CHMCache.java
+++ b/src/main/java/com/maxmind/db/CHMCache.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ContainerNode;
 
 /**
  * A simplistic cache using a {@link ConcurrentHashMap}. There's no eviction
@@ -41,9 +40,6 @@ public class CHMCache implements NodeCache {
                     cacheFull = true;
                 }
             }
-        }
-        if (value instanceof ContainerNode) {
-            value = value.deepCopy();
         }
         return value;
     }

--- a/src/main/java/com/maxmind/db/Decoder.java
+++ b/src/main/java/com/maxmind/db/Decoder.java
@@ -6,6 +6,11 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -257,26 +262,27 @@ final class Decoder {
     }
 
     private JsonNode decodeArray(int size) throws IOException {
-        ArrayNode array = OBJECT_MAPPER.createArrayNode();
 
+        List<JsonNode> array = new ArrayList<JsonNode>(size);
         for (int i = 0; i < size; i++) {
             JsonNode r = this.decode();
             array.add(r);
         }
 
-        return array;
+        return new ArrayNode(OBJECT_MAPPER.getNodeFactory(), Collections.unmodifiableList(array));
     }
 
     private JsonNode decodeMap(int size) throws IOException {
-        ObjectNode map = OBJECT_MAPPER.createObjectNode();
+        int capacity = (int) (size / 0.75F + 1.0F);
+        Map<String, JsonNode> map = new HashMap<String, JsonNode>(capacity);
 
         for (int i = 0; i < size; i++) {
             String key = this.decode().asText();
             JsonNode value = this.decode();
-            map.set(key, value);
+            map.put(key, value);
         }
 
-        return map;
+        return new ObjectNode(OBJECT_MAPPER.getNodeFactory(), Collections.unmodifiableMap(map));
     }
 
     private byte[] getByteArray(int length) {


### PR DESCRIPTION
Note, this requires Jackson 2.7.x.

Refs #13.