### PR TITLE
Update jackson-databind to version 2.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.9</version>
+            <version>2.9.2</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
to align with the same version that is being used by MaxMind GeoIP2 API 2.10.0