### PR TITLE
Correctly decode strings that are between 157 and 284 bytes long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+1.3.1 (2020-03-02)
+------------------
+
+* Correctly decode strings that are between 157 and 288 bytes long. 1.3.0
+  introduced a regression when decoding these due to using a signed `byte`
+  as an unsigned value. Reported by Dongmin Yu. GitHub #181 in
+  maxmind/GeoIP2-java.
+
 1.3.0 (2019-12-13)
 ------------------
 

--- a/src/main/java/com/maxmind/db/Decoder.java
+++ b/src/main/java/com/maxmind/db/Decoder.java
@@ -133,7 +133,7 @@ final class Decoder {
         if (size >= 29) {
             switch (size) {
                 case 29:
-                    size = 29 + buffer.get();
+                    size = 29 + (0xFF & buffer.get());
                     break;
                 case 30:
                     size = 285 + decodeInteger(2);

--- a/src/test/java/com/maxmind/db/DecoderTest.java
+++ b/src/test/java/com/maxmind/db/DecoderTest.java
@@ -153,8 +153,12 @@ public class DecoderTest {
                 "1234567890123456789012345678");
         DecoderTest.addTestString(strings, new byte[]{0x5d, 0x0},
                 "12345678901234567890123456789");
-        DecoderTest.addTestString(strings, new byte[]{0x5d, 0x1},
-                "123456789012345678901234567890");
+        DecoderTest.addTestString(strings, new byte[]{0x5d, (byte) 128},
+                DecoderTest.xString(157));
+
+        DecoderTest
+                .addTestString(strings, new byte[]{0x5d, 0x0, (byte) 0xd7},
+                        DecoderTest.xString(500));
 
         DecoderTest
                 .addTestString(strings, new byte[]{0x5e, 0x0, (byte) 0xd7},


### PR DESCRIPTION
See https://github.com/maxmind/GeoIP2-java/issues/181