### PR TITLE
Remove unnecessary synchronized

### DIFF
--- a/src/main/java/com/maxmind/db/BufferHolder.java
+++ b/src/main/java/com/maxmind/db/BufferHolder.java
@@ -57,7 +57,7 @@ final class BufferHolder {
      * Returns a duplicate of the underlying ByteBuffer. The returned ByteBuffer
      * should not be shared between threads.
      */
-    synchronized ByteBuffer get() {
+    ByteBuffer get() {
         return this.buffer.duplicate();
     }
 }


### PR DESCRIPTION
This synchronized call can cause contention.
There is no other code that is synchronized on the BufferHolder
The internal buffer never mutates its state (position, limit, and mark)

Thus it should be safe to remove this synchronized call.