### PR TITLE
Pass Type parameter through when loading via cache

### DIFF
--- a/src/main/java/com/maxmind/db/CHMCache.java
+++ b/src/main/java/com/maxmind/db/CHMCache.java
@@ -16,7 +16,7 @@ public class CHMCache implements NodeCache {
     private static final int DEFAULT_CAPACITY = 4096;
 
     private final int capacity;
-    private final ConcurrentHashMap<Integer, Object> cache;
+    private final ConcurrentHashMap<CacheKey, Object> cache;
     private boolean cacheFull = false;
 
     public CHMCache() {
@@ -29,19 +29,18 @@ public class CHMCache implements NodeCache {
     }
 
     @Override
-    public Object get(int key, Class<?> cls, Loader loader)
+    public Object get(CacheKey key, Loader loader)
             throws IOException,
                    InstantiationException,
                    IllegalAccessException,
                    InvocationTargetException,
                    NoSuchMethodException {
-        Integer k = key;
-        Object value = cache.get(k);
+        Object value = cache.get(key);
         if (value == null) {
-            value = loader.load(key, cls);
+            value = loader.load(key);
             if (!cacheFull) {
                 if (cache.size() < capacity) {
-                    cache.put(k, value);
+                    cache.put(key, value);
                 } else {
                     cacheFull = true;
                 }

--- a/src/main/java/com/maxmind/db/CacheKey.java
+++ b/src/main/java/com/maxmind/db/CacheKey.java
@@ -1,0 +1,64 @@
+package com.maxmind.db;
+
+public final class CacheKey<T> {
+    private final int offset;
+    private final Class<T> cls;
+    private final java.lang.reflect.Type type;
+
+    public CacheKey(int offset, Class<T> cls, java.lang.reflect.Type type) {
+        this.offset = offset;
+        this.cls = cls;
+        this.type = type;
+    }
+
+    public int getOffset() {
+        return this.offset;
+    }
+
+    public Class<T> getCls() {
+        return this.cls;
+    }
+
+    public java.lang.reflect.Type getType() {
+        return this.type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+
+        CacheKey other = (CacheKey) o;
+
+        if (this.offset != other.offset) {
+            return false;
+        }
+
+        if (this.cls == null) {
+            if (other.cls != null) {
+                return false;
+            }
+        } else if (!this.cls.equals(other.cls)) {
+            return false;
+        }
+
+        if (this.type == null) {
+            if (other.type != null) {
+                return false;
+            }
+        } else if (!this.type.equals(other.type)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = offset;
+        result = 31 * result + (cls == null ? 0 : cls.hashCode());
+        result = 31 * result + (type == null ? 0 : type.hashCode());
+        return result;
+    }
+}

--- a/src/main/java/com/maxmind/db/CacheKey.java
+++ b/src/main/java/com/maxmind/db/CacheKey.java
@@ -5,21 +5,21 @@ public final class CacheKey<T> {
     private final Class<T> cls;
     private final java.lang.reflect.Type type;
 
-    public CacheKey(int offset, Class<T> cls, java.lang.reflect.Type type) {
+    CacheKey(int offset, Class<T> cls, java.lang.reflect.Type type) {
         this.offset = offset;
         this.cls = cls;
         this.type = type;
     }
 
-    public int getOffset() {
+    int getOffset() {
         return this.offset;
     }
 
-    public Class<T> getCls() {
+    Class<T> getCls() {
         return this.cls;
     }
 
-    public java.lang.reflect.Type getType() {
+    java.lang.reflect.Type getType() {
         return this.type;
     }
 

--- a/src/main/java/com/maxmind/db/NoCache.java
+++ b/src/main/java/com/maxmind/db/NoCache.java
@@ -16,13 +16,13 @@ public class NoCache implements NodeCache {
     }
 
     @Override
-    public Object get(int key, Class<?> cls, Loader loader)
+    public Object get(CacheKey key, Loader loader)
             throws IOException,
                    InstantiationException,
                    IllegalAccessException,
                    InvocationTargetException,
                    NoSuchMethodException {
-        return loader.load(key, cls);
+        return loader.load(key);
     }
 
     public static NoCache getInstance() {

--- a/src/main/java/com/maxmind/db/NodeCache.java
+++ b/src/main/java/com/maxmind/db/NodeCache.java
@@ -8,15 +8,15 @@ import java.lang.reflect.InvocationTargetException;
 public interface NodeCache {
 
     interface Loader {
-        Object load(int key, Class<?> cls)
+        Object load(CacheKey key)
             throws IOException,
                    InstantiationException,
                    IllegalAccessException,
                    InvocationTargetException,
-                   NoSuchMethodException ;
+                   NoSuchMethodException;
     }
 
-    Object get(int key, Class<?> cls, Loader loader)
+    Object get(CacheKey key, Loader loader)
             throws IOException,
                    InstantiationException,
                    IllegalAccessException,


### PR DESCRIPTION
Previously the lack of this meant that we'd not decode to the expected
type in cases such as List<Foo>. This was because Type wasn't passed
through given the call to decode() didn't include it.

This also now takes into account the class and type in the cache key,
where previously we could behave return a different class than expected
if deserializing into two different classes.