### PR TITLE
Do not cast() when retrieving from cache

### DIFF
--- a/src/main/java/com/maxmind/db/Decoder.java
+++ b/src/main/java/com/maxmind/db/Decoder.java
@@ -77,7 +77,7 @@ final class Decoder {
         return cls.cast(decode(cls, null));
     }
 
-    private <T> T decode(CacheKey<T> key) throws IOException {
+    private <T> Object decode(CacheKey<T> key) throws IOException {
         int offset = key.getOffset();
         if (offset >= this.buffer.capacity()) {
             throw new InvalidDatabaseException(
@@ -87,7 +87,7 @@ final class Decoder {
 
         this.buffer.position(offset);
         Class<T> cls = key.getCls();
-        return cls.cast(decode(cls, key.getType()));
+        return decode(cls, key.getType());
     }
 
     private <T> Object decode(Class<T> cls, java.lang.reflect.Type genericType)
@@ -114,7 +114,7 @@ final class Decoder {
             int position = buffer.position();
 
             CacheKey key = new CacheKey(targetOffset, cls, genericType);
-            T o = cls.cast(cache.get(key, cacheLoader));
+            Object o = decode(key);
 
             buffer.position(position);
             return o;

--- a/src/test/java/com/maxmind/db/ReaderTest.java
+++ b/src/test/java/com/maxmind/db/ReaderTest.java
@@ -133,25 +133,38 @@ public class ReaderTest {
     @Test
     public void testDecodingTypesFile() throws IOException {
         this.testReader = new Reader(getFile("MaxMind-DB-test-decoder.mmdb"));
-        this.testDecodingTypes(this.testReader);
-        this.testDecodingTypesIntoModelObject(this.testReader);
-        this.testDecodingTypesIntoModelObjectBoxed(this.testReader);
+        this.testDecodingTypes(this.testReader, true);
+        this.testDecodingTypesIntoModelObject(this.testReader, true);
+        this.testDecodingTypesIntoModelObjectBoxed(this.testReader, true);
         this.testDecodingTypesIntoModelWithList(this.testReader);
     }
 
     @Test
     public void testDecodingTypesStream() throws IOException {
         this.testReader = new Reader(getStream("MaxMind-DB-test-decoder.mmdb"));
-        this.testDecodingTypes(this.testReader);
-        this.testDecodingTypesIntoModelObject(this.testReader);
-        this.testDecodingTypesIntoModelObjectBoxed(this.testReader);
+        this.testDecodingTypes(this.testReader, true);
+        this.testDecodingTypesIntoModelObject(this.testReader, true);
+        this.testDecodingTypesIntoModelObjectBoxed(this.testReader, true);
         this.testDecodingTypesIntoModelWithList(this.testReader);
     }
 
-    private void testDecodingTypes(Reader reader) throws IOException {
+    @Test
+    public void testDecodingTypesPointerDecoderFile() throws IOException {
+        this.testReader = new Reader(getFile("MaxMind-DB-test-pointer-decoder.mmdb"));
+        this.testDecodingTypes(this.testReader, false);
+        this.testDecodingTypesIntoModelObject(this.testReader, false);
+        this.testDecodingTypesIntoModelObjectBoxed(this.testReader, false);
+        this.testDecodingTypesIntoModelWithList(this.testReader);
+    }
+
+    private void testDecodingTypes(Reader reader, boolean booleanValue) throws IOException {
         Map record = reader.get(InetAddress.getByName("::1.1.1.0"), Map.class);
 
-        assertTrue((boolean) record.get("boolean"));
+        if (booleanValue) {
+            assertTrue((boolean) record.get("boolean"));
+        } else {
+            assertFalse((boolean) record.get("boolean"));
+        }
 
         assertArrayEquals(new byte[]{0, 0, 0, (byte) 42}, (byte[]) record
                 .get("bytes"));
@@ -191,11 +204,15 @@ public class ReaderTest {
                 (BigInteger) record.get("uint128"));
     }
 
-    private void testDecodingTypesIntoModelObject(Reader reader)
+    private void testDecodingTypesIntoModelObject(Reader reader, boolean booleanValue)
             throws IOException {
         TestModel model = reader.get(InetAddress.getByName("::1.1.1.0"), TestModel.class);
 
-        assertTrue(model.booleanField);
+        if (booleanValue) {
+            assertTrue(model.booleanField);
+        } else {
+            assertFalse(model.booleanField);
+        }
 
         assertArrayEquals(new byte[]{0, 0, 0, (byte) 42}, model.bytesField);
 
@@ -307,11 +324,15 @@ public class ReaderTest {
         }
     }
 
-    private void testDecodingTypesIntoModelObjectBoxed(Reader reader)
+    private void testDecodingTypesIntoModelObjectBoxed(Reader reader, boolean booleanValue)
             throws IOException {
         TestModelBoxed model = reader.get(InetAddress.getByName("::1.1.1.0"), TestModelBoxed.class);
 
-        assertTrue(model.booleanField);
+        if (booleanValue) {
+            assertTrue(model.booleanField);
+        } else {
+            assertFalse(model.booleanField);
+        }
 
         assertArrayEquals(new byte[]{0, 0, 0, (byte) 42}, model.bytesField);
 


### PR DESCRIPTION
This lead to issues when decoding primitives from the cache, such as
booleans: Cannot cast java.lang.Boolean to boolean. The non cache path
worked because the Boolean would be unboxed transparently.