### PR TITLE
Specify java release version to use when building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,4 +130,22 @@
         <artifactId>oss-parent</artifactId>
         <version>7</version>
     </parent>
+    <profiles>
+        <profile>
+            <id>active-on-jdk-9-plus</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <release>8</release>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This is because I am seeing

java.lang.NoSuchMethodError:
java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer;

when running on Java 8 when using this in GeoIP2-java.

See https://github.com/eclipse/jetty.project/issues/3244.