### PR TITLE
Support Android 7 and before

### DIFF
--- a/src/main/java/com/maxmind/db/Decoder.java
+++ b/src/main/java/com/maxmind/db/Decoder.java
@@ -394,7 +394,7 @@ final class Decoder {
 
             parameterIndexes = new HashMap<>();
             Annotation[][] annotations = constructor.getParameterAnnotations();
-            for (int i = 0; i < constructor.getParameterCount(); i++) {
+            for (int i = 0; i < constructor.getParameterTypes().length; i++) {
                 String parameterName = this.getParameterName(cls, i, annotations[i]);
                 parameterIndexes.put(parameterName, i);
             }


### PR DESCRIPTION
The `getParameterCount` method [is only available since Android 8](https://developer.android.com/reference/java/lang/reflect/Method#getParameterCount()) (API level 26). Using it on Android 7 causes a run time crash. As suggested in https://bugs.openjdk.java.net/browse/JDK-8098223, the `getParameterCount` call can be replaced with `getParameterTypes().length` to support Android 7 and before.