### PR TITLE
Issue #126 - Improve error handling in Decoder.decodeMapIntoMap() 

### DIFF
--- a/src/main/java/com/maxmind/db/Decoder.java
+++ b/src/main/java/com/maxmind/db/Decoder.java
@@ -372,7 +372,12 @@ final class Decoder {
         for (int i = 0; i < size; i++) {
             String key = (String) this.decode(String.class, null).getValue();
             Object value = this.decode(valueClass, null).getValue();
-            map.put(key, valueClass.cast(value));
+            try {
+                map.put(key, valueClass.cast(value));
+            } catch (ClassCastException e) {
+                throw new DeserializationException(
+                        "Error creating map entry for '" + key + "': " + e.getMessage(), e);
+            }
         }
 
         return map;

--- a/src/test/java/com/maxmind/db/ReaderTest.java
+++ b/src/test/java/com/maxmind/db/ReaderTest.java
@@ -1,6 +1,7 @@
 package com.maxmind.db;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -620,6 +621,17 @@ public class ReaderTest {
         assertThat(ex.getMessage(), containsString("Error getting record for IP"));
     }
 
+    @Test
+    public void testDecodeWithDataTypeMismatchInModel() throws IOException {
+        this.testReader = new Reader(getFile("GeoIP2-City-Test.mmdb"));
+        DeserializationException ex = assertThrows(DeserializationException.class,
+                () -> this.testReader.get(InetAddress.getByName("2.125.160.216"),
+                        TestDataTypeMismatchInModel.class));
+        assertThat(ex.getMessage(), containsString("Error getting record for IP"));
+        assertThat(ex.getMessage(), containsString("Error creating map entry for"));
+        assertThat(ex.getCause().getCause().getClass(), equalTo(ClassCastException.class));
+    }
+
     static class TestWrongModelSubdivisions {
         List<TestWrongModelSubdivision> subdivisions;
 
@@ -641,6 +653,18 @@ public class ReaderTest {
             Integer uint16Field
         ) {
             this.uint16Field = uint16Field;
+        }
+    }
+
+    static class TestDataTypeMismatchInModel {
+        Map<String, Float> location;
+
+        @MaxMindDbConstructor
+        public TestDataTypeMismatchInModel(
+                @MaxMindDbParameter(name = "location")
+                Map<String, Float> location
+        ) {
+            this.location = location;
         }
     }
 


### PR DESCRIPTION
This PR aims to improve the error handling of Decoder.decodeMapIntoMap() by:
- Catching ClassCastException and transform into DeserializationException with an appropriate message

This logic should be in line with the error handling seen in Decoder.decodeMapIntoObject().

ReaderTest has been extended with a new test; this exercises the handling a datatype mismatch between the schema in the MMDB file and the provided class to populate