### PR TITLE
Fix dependabot snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,9 @@
             </plugin>
         </plugins>
     </build>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
     <profiles>
         <profile>
             <id>active-on-jdk-9-plus</id>

--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,6 @@
             </plugin>
         </plugins>
     </build>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
     <profiles>
         <profile>
             <id>active-on-jdk-9-plus</id>


### PR DESCRIPTION
Dependabot will stop looking for maven dependencies once it finds a repository that returns any number of results, even if none of those results match the requested version. This removes the ossrh repository because it brings in snapshot repositories that prevent dependabot from falling back to the central repository. See: dependabot/dependabot-core#5872