### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ dependencies {
 
 ## Usage ##
 
-*Note:* For accessing MaxMind GeoIP2 databases, we generally recommend using
+*Note:* For accessing MaxMind GeoIP databases, we generally recommend using
 the [GeoIP2 Java API](https://maxmind.github.io/GeoIP2-java/) rather than using
 this package directly.
 

--- a/src/main/java/com/maxmind/db/Reader.java
+++ b/src/main/java/com/maxmind/db/Reader.java
@@ -48,7 +48,7 @@ public final class Reader implements Closeable {
 
     /**
      * Constructs a Reader for the MaxMind DB format, with no caching. The file
-     * passed to it must be a valid MaxMind DB file such as a GeoIP2 database
+     * passed to it must be a valid MaxMind DB file such as a GeoIP database
      * file.
      *
      * @param database the MaxMind DB file to use.
@@ -73,7 +73,7 @@ public final class Reader implements Closeable {
     /**
      * Constructs a Reader for the MaxMind DB format, with the specified backing
      * cache. The file passed to it must be a valid MaxMind DB file such as a
-     * GeoIP2 database file.
+     * GeoIP database file.
      *
      * @param database the MaxMind DB file to use.
      * @param cache    backing cache instance
@@ -124,7 +124,7 @@ public final class Reader implements Closeable {
 
     /**
      * Constructs a Reader for the MaxMind DB format, with no caching. The file
-     * passed to it must be a valid MaxMind DB file such as a GeoIP2 database
+     * passed to it must be a valid MaxMind DB file such as a GeoIP database
      * file.
      *
      * @param database the MaxMind DB file to use.
@@ -138,7 +138,7 @@ public final class Reader implements Closeable {
     /**
      * Constructs a Reader for the MaxMind DB format, with the specified backing
      * cache. The file passed to it must be a valid MaxMind DB file such as a
-     * GeoIP2 database file.
+     * GeoIP database file.
      *
      * @param database the MaxMind DB file to use.
      * @param fileMode the mode to open the file with.


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) and test fixtures are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)