### PR TITLE
Validate and update links (STF-557)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,32 @@
+name: Links
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 13 * * 1" # weekly, to catch external link rot without a commit
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        with:
+          install: false
+
+      # Install only lychee (not the repo's full toolchain) and run the check.
+      - name: Check links
+        env:
+          MISE_AUTO_INSTALL: "false"
+        run: |
+          mise install lychee
+          mise run check-links

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ target
 /sample/run.sh
 reports
 Test.java
+.lycheecache

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Please report all issues with this code using the [GitHub issue
 tracker](https://github.com/maxmind/MaxMind-DB-Reader-java/issues).
 
 If you are having an issue with a MaxMind database or service that is not
-specific to this reader, please [contact MaxMind support](https://www.maxmind.com/en/support).
+specific to this reader, please [contact MaxMind support](https://support.maxmind.com/knowledge-base).
 
 ## Requirements  ##
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -252,4 +252,4 @@ To help identify code that needs updating, you can search your codebase for:
 If you encounter issues during the upgrade, please check:
 
 - [GitHub Issues](https://github.com/maxmind/MaxMind-DB-Reader-java/issues)
-- [MaxMind Support](https://www.maxmind.com/en/support)
+- [MaxMind Support](https://support.maxmind.com/knowledge-base)

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,63 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/#/usage/config
+#
+# Run locally with:
+#   lychee './**/*.md' './src/**/*.java' './pom.xml'
+
+# Include URL fragments in checks
+include_fragments = true
+
+# Don't allow any redirects, so links that have moved are surfaced and updated
+# to their canonical destination.
+max_redirects = 0
+
+# Accept these HTTP status codes
+# 100-103: Informational responses
+# 200-299: Success responses
+# 403: Forbidden (some sites use this for rate limiting)
+# 429: Too Many Requests
+# 500-599: Server errors (temporary issues shouldn't fail CI)
+# 999: LinkedIn's custom status code
+accept = ["100..=103", "200..=299", "403", "429", "500..=599", "999"]
+
+# Exclude URL patterns from checking (treated as regular expressions)
+exclude = [
+    '^file://',
+    # Live / auth-gated endpoints that appear as string literals or require login
+    '^https://geoip\.maxmind\.com',
+    '^https://geolite\.info',
+    '^https://minfraud\.maxmind\.com',
+    '^https://sandbox\.maxmind\.com',
+    '^https://updates\.maxmind\.com',
+    '^https://www\.maxmind\.com/en/accounts/',
+    'https://www\.maxmind\.com/en/account/login',
+    # XML namespace identifiers in pom.xml (not real links)
+    '^http://www\.w3\.org/',
+    '^http://maven\.apache\.org/',
+    '^https://maven\.apache\.org/xsd/',
+    '^http://java\.sun\.com/',
+    '^http://schemas\.',
+    # Maven property placeholder in a build-time download URL (not a real link)
+    'japicmp\.baselineVersion',
+    # Placeholders / local
+    '^https?://example\.(com|org|net)',
+    '^http://localhost',
+    '127\.0\.0\.1',
+]
+
+# Exclude file paths from getting checked (treated as regular expressions)
+exclude_path = [
+    '(^|/)node_modules/',
+    '(^|/)target/',
+    # Test fixtures (MaxMind-DB submodule) contain example URLs, not ours
+    '(^|/)src/test/resources/',
+    # Changelog: historical entries are preserved as-is, not rewritten
+    '(^|/)CHANGELOG\.md$',
+]
+
+# Cache results for 1 day to speed up repeated checks
+cache = true
+max_cache_age = "1d"
+
+# Skip missing input files instead of erroring
+skip_missing = true

--- a/mise.lock
+++ b/mise.lock
@@ -40,6 +40,34 @@ backend = "core:java"
 checksum = "sha256:2f2802d57b5fc414f1ddf6648ba12cc9a6454cf67b32ac95407c018f2e6ab0b0"
 url = "https://download.java.net/java/GA/jdk26.0.1/458fda22e4c54d5ba572ab8d2b22eb83/8/GPL/openjdk-26.0.1_linux-x64_bin.tar.gz"
 
+[[tools.lychee]]
+version = "0.23.0"
+backend = "aqua:lycheeverse/lychee"
+
+[tools.lychee."platforms.linux-arm64"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-arm64-musl"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-x64"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.linux-x64-musl"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.macos-arm64"]
+checksum = "sha256:4c8034900e11083b68ac6f6582c377ff1f704e268991999e09d717973e493e7f"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-arm64-macos.dmg"
+
+[tools.lychee."platforms.windows-x64"]
+checksum = "sha256:0fda7ff0a60c0250939fc25361c2d4e6e7853c31c996733fdd5a1dd760bcb824"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-windows.exe"
+
 [[tools.maven]]
 version = "3.9.15"
 backend = "aqua:apache/maven"

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,7 @@ disable_backends = [
 [tools]
 hugo = "latest"
 java = "latest"
+lychee = "latest"
 maven = "latest"
 
 [tasks.build-docs]
@@ -18,6 +19,10 @@ run = "hugo --source docs --minify"
 [tasks.serve-docs]
 description = "Serve the docs site locally with Hugo dev server"
 run = "hugo server --source docs"
+
+[tasks.check-links]
+description = "Check links with lychee"
+run = "lychee --no-progress './**/*.md' './src/**/*.java' './pom.xml'"
 
 [hooks]
 enter = "mise install --quiet --locked"

--- a/pom.xml
+++ b/pom.xml
@@ -7,17 +7,17 @@
     <packaging>jar</packaging>
     <name>MaxMind DB Reader</name>
     <description>Reader for MaxMind DB</description>
-    <url>http://dev.maxmind.com/</url>
+    <url>https://dev.maxmind.com/</url>
     <licenses>
         <license>
             <name>Apache License 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
     <organization>
         <name>MaxMind, Inc.</name>
-        <url>http://www.maxmind.com/</url>
+        <url>https://www.maxmind.com/en/home</url>
     </organization>
     <scm>
         <url>https://github.com/maxmind/MaxMind-DB-Reader-java</url>


### PR DESCRIPTION
Add a [lychee](https://lychee.cli.rs/) link-checker config (`lychee.toml`) and a
CI workflow (`.github/workflows/links.yml`), and fix stale/redirecting links
surfaced by running it.

The config mirrors the shared MaxMind setup: `max_redirects = 0` so moved links
are surfaced, `500..=599` accepted so transient server errors don't fail CI, XML
namespace identifiers and the japicmp baseline-version placeholder excluded as
false positives, and the `target/` build dir plus the `src/test/resources/`
MaxMind-DB submodule fixtures excluded from scanning.

Links updated (old -> new):

- `http://dev.maxmind.com/` -> `https://dev.maxmind.com/` (pom.xml)
- `http://www.apache.org/licenses/LICENSE-2.0.html` -> `https://www.apache.org/licenses/LICENSE-2.0.html` (pom.xml)
- `http://www.maxmind.com/` -> `https://www.maxmind.com/en/home` (pom.xml)
- `https://www.maxmind.com/en/support` -> `https://support.maxmind.com/knowledge-base` (README.md, UPGRADING.md)

After the fixes, lychee reports: `28 Total, 21 OK, 0 Errors, 7 Excluded`.

Part of STF-557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)