### PR TITLE
Fix gh-pages deploy: restore java lock URL and build docs on PRs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,12 +3,13 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: ["main"]
+  pull_request:
   workflow_dispatch:
 
 permissions: {}
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -31,7 +32,11 @@ jobs:
           HUGO_BASEURL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
         run: mise run build-docs
 
+      # Only publish from pushes to main. On pull requests the steps above
+      # still run (building the docs and exercising `mise install --locked`),
+      # so a broken lockfile or docs build is caught before merge.
       - name: Push rendered site to gh-pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/mise.lock
+++ b/mise.lock
@@ -39,6 +39,26 @@ backend = "core:java"
 [tools.java.options]
 shorthand_vendor = "openjdk"
 
+[tools.java."platforms.linux-arm64"]
+checksum = "sha256:12a3649b2f4a0c9f6491d220bdd04b4fff07cae502b435aaff46eac0e36f4df1"
+url = "https://download.java.net/java/GA/jdk26.0.1/458fda22e4c54d5ba572ab8d2b22eb83/8/GPL/openjdk-26.0.1_linux-aarch64_bin.tar.gz"
+
+[tools.java."platforms.linux-x64"]
+checksum = "sha256:2f2802d57b5fc414f1ddf6648ba12cc9a6454cf67b32ac95407c018f2e6ab0b0"
+url = "https://download.java.net/java/GA/jdk26.0.1/458fda22e4c54d5ba572ab8d2b22eb83/8/GPL/openjdk-26.0.1_linux-x64_bin.tar.gz"
+
+[tools.java."platforms.macos-arm64"]
+checksum = "sha256:b2d57405194a312ed4ec6ec08e83b314d3fd2e425e895d704ec5ef8ea6059e17"
+url = "https://download.java.net/java/GA/jdk26.0.1/458fda22e4c54d5ba572ab8d2b22eb83/8/GPL/openjdk-26.0.1_macos-aarch64_bin.tar.gz"
+
+[tools.java."platforms.macos-x64"]
+checksum = "sha256:e52bc05aefe4991329a6a103c9b42ae4b9b77240a9f9d3d12f6a7365db1ae16a"
+url = "https://download.java.net/java/GA/jdk26.0.1/458fda22e4c54d5ba572ab8d2b22eb83/8/GPL/openjdk-26.0.1_macos-x64_bin.tar.gz"
+
+[tools.java."platforms.windows-x64"]
+checksum = "sha256:b381d30647aed9ff440abed5ab61af01d8578c290cd407c57e064ebc4b0151be"
+url = "https://download.java.net/java/GA/jdk26.0.1/458fda22e4c54d5ba572ab8d2b22eb83/8/GPL/openjdk-26.0.1_windows-x64_bin.zip"
+
 [[tools.lychee]]
 version = "0.24.2"
 backend = "aqua:lycheeverse/lychee"


### PR DESCRIPTION
The "Deploy to GitHub Pages" workflow failed on `main` after #401 merged (run `28465860134`).

## Root cause
The deploy's `Setup mise` step runs `mise install --locked`, which installs the **full** toolchain — including `java`. The `mise.lock` update in #401 (commit `3b9ddb1`) replaced java's per-platform `url`/`checksum` entry with a bare `[tools.java.options] shorthand_vendor = "openjdk"`. With no locked URL, the install fails:

```
mise ERROR Failed to install core:java@latest: No lockfile URL found for java@26.0.1 on platform linux-x64 (--locked mode)
```

It wasn't caught on the PR because `pages.yml` only triggered on `push: [main]`, and the PR job that uses mise (`links.yml`) installs lychee-only (`install: false`) — so no PR ran the full locked install.

## Changes (two commits)
1. **Restore java platform URL in `mise.lock`** — recovers `mise install --locked` so the Pages deploy works again. (Restored byte-identical to the pre-#401 lockfile entry; the hugo/lychee/maven bumps from #401 are untouched.)
2. **Build docs on pull requests** — `pages.yml` now also runs on `pull_request`, executing `Setup mise` (full `mise install --locked`) + `Build docs`, with the gh-pages publish step gated to pushes on `main`. A broken lockfile or docs build now fails the PR before merge. Concurrency group is scoped per-ref so PR runs don't cancel the main deploy.

Companion to maxmind/GeoIP2-java#734, which had the same failure.

Note: commits are unsigned because the local 1Password signing agent was unavailable at authoring time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Pages builds now run for pull requests and manual triggers.
* **Bug Fixes**
  * Prevented preview builds from publishing to the live Pages site.
  * Improved workflow concurrency so only the latest run for a ref continues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->