### PR TITLE
Decode data pointers as unsigned to support offsets past 2 GiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+4.1.1
+------------------
+
+* Fixed decoding of data pointers with offsets of 2 GiB or greater. The
+  pointer payload was decoded into an `int`, so such offsets were
+  sign-extended to a negative value and rejected by `Buffer.position()`
+  with an `IllegalArgumentException`. Every record past the 2 GiB
+  boundary was unreachable in databases larger than 2 GiB, which have
+  been supported since 4.0.0.
+
 4.1.0 (2026-05-12)
 ------------------
 

--- a/src/main/java/com/maxmind/db/Decoder.java
+++ b/src/main/java/com/maxmind/db/Decoder.java
@@ -133,7 +133,7 @@ class Decoder {
         if (type.equals(Type.POINTER)) {
             var pointerSize = ((ctrlByte >>> 3) & 0x3) + 1;
             var base = pointerSize == 4 ? (byte) 0 : (byte) (ctrlByte & 0x7);
-            var packed = this.decodeInteger(base, pointerSize);
+            var packed = Decoder.decodeLong(this.buffer, base, pointerSize);
             var pointer = packed + this.pointerBase + POINTER_VALUE_OFFSETS[pointerSize];
 
             return decodePointer(pointer, cls, genericType);

--- a/src/test/java/com/maxmind/db/PointerTest.java
+++ b/src/test/java/com/maxmind/db/PointerTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.maxmind.db.Reader.FileMode;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
 public class PointerTest {
@@ -40,5 +42,23 @@ public class PointerTest {
         map = new HashMap<>();
         map.put("long_key2", "long_value2");
         assertEquals(map, decoder.decode(57, Map.class));
+    }
+
+    @SuppressWarnings("static-method")
+    @Test
+    public void testPointerBeyond2GiBIsNotSignExtended() throws IOException {
+        // Control byte for a four-byte pointer, followed by the offset 3473557240.
+        var buffer = new SingleBuffer(ByteBuffer.wrap(new byte[]{
+            (byte) 0x38, (byte) 0xCF, (byte) 0x0A, (byte) 0x46, (byte) 0xF8}));
+
+        var observed = new AtomicLong(Long.MIN_VALUE);
+        NodeCache cache = (key, loader) -> {
+            observed.set(key.offset());
+            return new DecodedValue(null);
+        };
+
+        new Decoder(cache, buffer, 0).decode(0, Object.class);
+
+        assertEquals(3473557240L, observed.get());
     }
 }


### PR DESCRIPTION
Fixes #435. Found while reading a ~3.4 GB third-party MMDB in production.

`Decoder.decodePointer` narrowed the pointer payload to `int`, so any data-section offset >= 2^31
was sign-extended to a negative value and `Buffer.position(...)` rejected it. On databases larger
than 2 GiB, the case #289 added support for, every record past the 2 GiB boundary was unreachable,
failing with e.g. `IllegalArgumentException: Invalid position: -821410056`
(`-821410056 + 2^32 = 3473557240`, a valid offset in the database).

**Change**

```diff
-var packed = this.decodeInteger(base, pointerSize);
+var packed = Decoder.decodeLong(this.buffer, base, pointerSize);
```

The 3-arg static form is used because pointer sizes 1-3 carry a non-zero `base` (`ctrlByte & 0x7`).
`decodeUint32` already reads unsigned 32-bit values through `decodeLong`; this brings the pointer
path in line with it. `nextValueOffset` only skips over pointers and is unaffected.

**Testing**

Added a regression test to `PointerTest` that drives a four-byte pointer through the decoder and
asserts the resulting offset. It fails on `main` with
`expected: <3473557240> but was: <-821410056>` and passes with the change.

The test builds the pointer bytes directly, so it needs no large fixture, per note on #289
that a large database in the test-data repo would impact the other projects pulling it in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed decoding for data pointers at or above 2 GiB.
  - Large pointer offsets are now interpreted correctly, preventing valid data from being rejected as invalid buffer positions.
- **Documentation**
  - Added a changelog entry describing the pointer-decoding fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->